### PR TITLE
Added ChoicelistNameSingle parameter to skin

### DIFF
--- a/usr/share/enigma2/GlamourAuraFHD/skin.xml
+++ b/usr/share/enigma2/GlamourAuraFHD/skin.xml
@@ -124,6 +124,7 @@
     <parameter name="ChoicelistDash" value="0,0,940,50" />
     <parameter name="ChoicelistName" value="60,0,940,50" />
     <parameter name="ChoicelistIcon" value="5,2,50,50" />
+    <parameter name="ChoicelistNameSingle" value="5,0,1000,50"/>
     <parameter name="ChoicelistFontSize" value="30" />
     <parameter name="SelectionListDescr" value="70,2,1000,50" />
     <parameter name="SelectionListLock" value="10,0,50,50" />


### PR DESCRIPTION
The issue you saw in your skin was a side effect of a change I made in openpli some time ago, plus [an oversight, I actually fixed 14 hours](https://github.com/OpenPLi/enigma2/pull/2313) ago! The extensions menu issue should be already fixed if you update to latest opnepli.

The present PR with the addition in your skin is for fixing the problem in the hotkey screens. A slight adjustment in the numbers might be needed. I didn't know how much space you need at the left. 

Anyway, the problem is so prominent in your skin, because you use a very larger item height (50) from the default 25. Other skins might not have such an issue.

See https://github.com/OpenPLi/enigma2/pull/2278 and https://github.com/OpenPLi/enigma2/pull/2279 for more details.